### PR TITLE
Garyelephant.fea.plugin docs

### DIFF
--- a/src/main/antlr4/PluginDoc.g4
+++ b/src/main/antlr4/PluginDoc.g4
@@ -1,6 +1,6 @@
 grammar PluginDoc;
 
-// TODO: pluginOption default value
+// TODO: pluginOption default value 不支持element是string(即包含quote)的array
 // TODO: 允许包含空格的字符串，目前的解决方案是quoted_string, TEXT与IDENTIFIER容易混淆
 // TODO: 丰富的plugin description, option description无法用简单的rule来表达, 需要直接引入markdown
 // TODO: udfs
@@ -72,7 +72,7 @@ pluginVersion
     ;
 
 pluginOption
-    : PluginOption optionType optionName optionRequired (optionDesc)?
+    : PluginOption optionType optionName (EQUAL optionDefaultValue)? optionRequired (optionDesc)?
     ;
 
 optionType
@@ -85,6 +85,10 @@ optionName
 
 optionRequired
     : YES | NO
+    ;
+
+optionDefaultValue
+    : TEXT
     ;
 
 optionDesc
@@ -124,6 +128,7 @@ NULL : 'null';
 
 YES : 'yes';
 NO : 'no';
+EQUAL : '=';
 
 // IDENTIFIER should be placed before TEXT to be matched first
 // IDENTIFIER should be placed before VERSION_NUMBER to be matched first
@@ -146,7 +151,7 @@ fragment URL_VALID_CHARS
     ;
 
 TEXT
-    : '"' ~( '\n' | '\t' )* '"'
+    : '"' ~( '"' | '\n' | '\t' )* '"'
     ;
 
 WS

--- a/src/main/antlr4/PluginDoc.g4
+++ b/src/main/antlr4/PluginDoc.g4
@@ -1,7 +1,9 @@
 grammar PluginDoc;
 
 // TODO: pluginOption default value 不支持element是string(即包含quote)的array
-// TODO: 允许包含空格的字符串，目前的解决方案是quoted_string, TEXT与IDENTIFIER容易混淆
+// TODO: 允许包含空格的字符串，目前的解决方案是quoted_string, TEXT与IDENTIFIER容易混淆,
+// see: https://stackoverflow.com/questions/6847971/antlr-identifier-with-whitespace
+// https://stackoverflow.com/questions/29060496/allow-whitespace-sections-antlr4
 // TODO: 丰富的plugin description, option description无法用简单的rule来表达, 需要直接引入markdown
 // TODO: udfs
 

--- a/src/main/antlr4/PluginDoc.g4
+++ b/src/main/antlr4/PluginDoc.g4
@@ -1,7 +1,9 @@
 grammar PluginDoc;
 
+// TODO: pluginOption is_required, default value
+// TODO: 允许包含空格的字符串，目前的解决方案是quoted_string, TEXT与IDENTIFIER容易混淆
+// TODO: 丰富的plugin description, option description无法用简单的rule来表达, 需要直接引入markdown
 // TODO: udfs
-// TOOD: all todos
 
 // 内容类型: string, url, quote_string, code, markdown
 // 能够写原始的markdown，能够指向链接，能够quote部分文字
@@ -28,7 +30,7 @@ grammar PluginDoc;
 // @pluginUDFExample
 
 waterdropPlugin
-    : WaterdropPlugin pluginBlock (udfBlock)*
+    : WaterdropPlugin pluginBlock EOF
     ;
 
 pluginBlock
@@ -82,11 +84,7 @@ optionName
     ;
 
 optionDesc
-    : 'desc' | 'desc2'// TODO
-    ;
-
-udfBlock
-    : 'tet'
+    : TEXT
     ;
 
 WaterdropPlugin : '@waterdropPlugin';
@@ -120,6 +118,10 @@ ARRAY : 'array';
 BOOLEAN : 'boolean';
 NULL : 'null';
 
+// IDENTIFIER should be placed before TEXT to be matched first
+// IDENTIFIER should be placed before VERSION_NUMBER to be matched first
+IDENTIFIER : [a-zA-Z_] [a-zA-Z_0-9]* ('.' [a-zA-Z_0-9]+)*;
+
 VERSION_NUMBER : [0-9]+ '.' [0-9]+ '.' + [0-9]+;
 
 URL : ('http' 's'? '://')? URL_VALID_CHARS ('.' URL_VALID_CHARS)+ ('/' | URL_PATH_FRAGMENT)* ('?' URL_PARAMS)?;
@@ -136,11 +138,8 @@ fragment URL_VALID_CHARS
     : [0-9a-z_-]+
     ;
 
-// IDENTIFIER should be placed before TEXT to be matched first
-IDENTIFIER : [a-zA-Z_] [a-zA-Z_0-9]* ('.' [a-zA-Z_0-9]+)*;
-
 TEXT
-    : ~( ' ' | '\n' | '\t' )+
+    : '"' ~( '\n' | '\t' )* '"'
     ;
 
 WS

--- a/src/main/antlr4/PluginDoc.g4
+++ b/src/main/antlr4/PluginDoc.g4
@@ -1,6 +1,6 @@
 grammar PluginDoc;
 
-// TODO: pluginOption is_required, default value
+// TODO: pluginOption default value
 // TODO: 允许包含空格的字符串，目前的解决方案是quoted_string, TEXT与IDENTIFIER容易混淆
 // TODO: 丰富的plugin description, option description无法用简单的rule来表达, 需要直接引入markdown
 // TODO: udfs
@@ -72,7 +72,7 @@ pluginVersion
     ;
 
 pluginOption
-    : PluginOption optionType optionName (optionDesc)?
+    : PluginOption optionType optionName optionRequired (optionDesc)?
     ;
 
 optionType
@@ -81,6 +81,10 @@ optionType
 
 optionName
     : IDENTIFIER
+    ;
+
+optionRequired
+    : YES | NO
     ;
 
 optionDesc
@@ -117,6 +121,9 @@ STRING : 'string';
 ARRAY : 'array';
 BOOLEAN : 'boolean';
 NULL : 'null';
+
+YES : 'yes';
+NO : 'no';
 
 // IDENTIFIER should be placed before TEXT to be matched first
 // IDENTIFIER should be placed before VERSION_NUMBER to be matched first

--- a/src/main/antlr4/PluginDoc.g4
+++ b/src/main/antlr4/PluginDoc.g4
@@ -1,0 +1,148 @@
+grammar PluginDoc;
+
+// TODO: udfs
+// TOOD: all todos
+
+// 内容类型: string, url, quote_string, code, markdown
+// 能够写原始的markdown，能够指向链接，能够quote部分文字
+// 或者开发者可以在生成的markdown doc上，修改markdown
+// pluginUDF 有可能会有多个
+
+// @waterdropPlugin
+// @pluginGroup input | filter | output
+
+// @pluginName
+// @pluginDesc
+
+// @pluginAuthor
+// @pluginHomepage
+// @pluginVersion
+
+// @pluginOption type name(required default_value) description
+// @pluginOptionsExample
+
+// @pluginUDF
+// @pluginUDFName
+// @pluginUDFDesc
+// @pluginUDFOptions order name desc type required default_value return_value_type
+// @pluginUDFExample
+
+waterdropPlugin
+    : WaterdropPlugin pluginBlock (udfBlock)*
+    ;
+
+pluginBlock
+    : (definition)+
+    ;
+
+definition
+    : pluginGroup
+    | pluginName
+    | pluginDesc
+    | pluginAuthor
+    | pluginHomepage
+    | pluginVersion
+    | pluginOption
+    ;
+
+pluginGroup
+    : PluginGroup (INPUT | FILTER | OUTPUT)
+    ;
+
+pluginName
+    : PluginName IDENTIFIER
+    ;
+
+pluginDesc
+    : PluginDesc (IDENTIFIER | TEXT)
+    ;
+
+pluginAuthor
+    : PluginAuthor (IDENTIFIER | TEXT)
+    ;
+
+pluginHomepage
+    : PluginHomepage URL
+    ;
+
+pluginVersion
+    : PluginVersion VERSION_NUMBER
+    ;
+
+pluginOption
+    : PluginOption optionType optionName (optionDesc)?
+    ;
+
+optionType
+    : NUMBER | STRING | ARRAY | BOOLEAN | NULL
+    ;
+
+optionName
+    : IDENTIFIER
+    ;
+
+optionDesc
+    : 'desc' | 'desc2'// TODO
+    ;
+
+udfBlock
+    : 'tet'
+    ;
+
+WaterdropPlugin : '@waterdropPlugin';
+PluginGroup : '@pluginGroup';
+
+PluginName : '@pluginName';
+PluginDesc : '@pluginDesc';
+
+PluginAuthor : '@pluginAuthor';
+PluginHomepage : '@pluginHomepage';
+PluginVersion : '@pluginVersion';
+
+PluginOption : '@pluginOption';
+PluginOptionsExample : '@pluginOptionsExample';
+
+PluginUDF : '@pluginUDF';
+PluginUDFName : '@pluginUDFName';
+PluginUDFDesc : '@pluginUDFDesc';
+PluginUDFOptions : '@pluginUDFOptions';
+PluginUDFExample : '@pluginUDFExample';
+
+// pluginGroup
+INPUT : 'input';
+FILTER : 'filter';
+OUTPUT : 'output';
+
+// optionType
+NUMBER : 'number';
+STRING : 'string';
+ARRAY : 'array';
+BOOLEAN : 'boolean';
+NULL : 'null';
+
+VERSION_NUMBER : [0-9]+ '.' [0-9]+ '.' + [0-9]+;
+
+URL : ('http' 's'? '://')? URL_VALID_CHARS ('.' URL_VALID_CHARS)+ ('/' | URL_PATH_FRAGMENT)* ('?' URL_PARAMS)?;
+
+fragment URL_PATH_FRAGMENT
+    : '/' URL_VALID_CHARS
+    ;
+
+fragment URL_PARAMS
+    : URL_VALID_CHARS '=' URL_VALID_CHARS ('&' URL_VALID_CHARS '=' URL_VALID_CHARS)*
+    ;
+
+fragment URL_VALID_CHARS
+    : [0-9a-z_-]+
+    ;
+
+// IDENTIFIER should be placed before TEXT to be matched first
+IDENTIFIER : [a-zA-Z_] [a-zA-Z_0-9]* ('.' [a-zA-Z_0-9]+)*;
+
+TEXT
+    : ~( ' ' | '\n' | '\t' )+
+    ;
+
+WS
+    : [ \t\n\r]+ -> skip
+    ;

--- a/src/main/antlr4/PluginDocExample.docs
+++ b/src/main/antlr4/PluginDocExample.docs
@@ -9,4 +9,4 @@
 @pluginOption array topics yes "a list of topics to consume"
 @pluginOption string consumer.bootstrap.servers yes "kafka broker list"
 @pluginOption string consumer.group.id yes "consumer group id"
-@pluginOption number consumer.num.consumer.fetchers no
+@pluginOption number consumer.num.consumer.fetchers="2" no

--- a/src/main/antlr4/PluginDocExample.docs
+++ b/src/main/antlr4/PluginDocExample.docs
@@ -1,0 +1,12 @@
+@waterdropPlugin
+@pluginGroup input
+@pluginName kafka
+@pluginDesc "get message from kafka"
+@pluginAuthor garyelephant
+@pluginHomepage https://interestinglab.github.io/waterdrop
+@pluginVersion 1.2.3
+
+@pluginOption array topics "a list of topics to consume"
+@pluginOption string consumer.bootstrap.servers "kafka broker list"
+@pluginOption string consumer.group.id "consumer group id"
+@pluginOption number consumer.num.consumer.fetchers

--- a/src/main/antlr4/PluginDocExample.docs
+++ b/src/main/antlr4/PluginDocExample.docs
@@ -6,7 +6,7 @@
 @pluginHomepage https://interestinglab.github.io/waterdrop
 @pluginVersion 1.2.3
 
-@pluginOption array topics "a list of topics to consume"
-@pluginOption string consumer.bootstrap.servers "kafka broker list"
-@pluginOption string consumer.group.id "consumer group id"
-@pluginOption number consumer.num.consumer.fetchers
+@pluginOption array topics yes "a list of topics to consume"
+@pluginOption string consumer.bootstrap.servers yes "kafka broker list"
+@pluginOption string consumer.group.id yes "consumer group id"
+@pluginOption number consumer.num.consumer.fetchers no

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDoc.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDoc.java
@@ -1,0 +1,125 @@
+package org.interestinglab.waterdrop.docutils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by gaoyingju on 17/09/2017.
+ */
+public class PluginDoc {
+
+    private String pluginGroup;
+    private String pluginName;
+    private String pluginDesc;
+    private String pluginAuthor;
+    private String pluginHomepage;
+    private String pluginVersion;
+    private List<PluginOption> pluginOptions = new ArrayList<>();
+
+    public static class PluginOption {
+
+        private String optionType;
+        private String optionName;
+        private String optionDesc;
+        private boolean required = true;
+
+        public PluginOption(final String optionType, final String optionName, final String optionDesc) {
+            this.optionType = optionType;
+            this.optionName = optionName;
+            this.optionDesc = optionDesc;
+        }
+
+        public String getOptionType() {
+            return optionType;
+        }
+
+        public void setOptionType(String optionType) {
+            this.optionType = optionType;
+        }
+
+        public String getOptionName() {
+            return optionName;
+        }
+
+        public void setOptionName(String optionName) {
+            this.optionName = optionName;
+        }
+
+        public String getOptionDesc() {
+            return optionDesc;
+        }
+
+        public void setOptionDesc(String optionDesc) {
+            this.optionDesc = optionDesc;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
+        }
+    }
+
+//    public static PluginOption newPluginOption(final String optionType, final String optionName, final String optionDesc) {
+//        return new PluginOption(optionType, optionName, optionDesc);
+//    }
+
+    public String getPluginGroup() {
+        return pluginGroup;
+    }
+
+    public void setPluginGroup(String pluginGroup) {
+        this.pluginGroup = pluginGroup;
+    }
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+    }
+
+    public String getPluginDesc() {
+        return pluginDesc;
+    }
+
+    public void setPluginDesc(String pluginDesc) {
+        this.pluginDesc = pluginDesc;
+    }
+
+    public String getPluginAuthor() {
+        return pluginAuthor;
+    }
+
+    public void setPluginAuthor(String pluginAuthor) {
+        this.pluginAuthor = pluginAuthor;
+    }
+
+    public String getPluginHomepage() {
+        return pluginHomepage;
+    }
+
+    public void setPluginHomepage(String pluginHomepage) {
+        this.pluginHomepage = pluginHomepage;
+    }
+
+    public String getPluginVersion() {
+        return pluginVersion;
+    }
+
+    public void setPluginVersion(String pluginVersion) {
+        this.pluginVersion = pluginVersion;
+    }
+
+    public List<PluginOption> getPluginOptions() {
+        return pluginOptions;
+    }
+
+    public void setPluginOptions(List<PluginOption> pluginOptions) {
+        this.pluginOptions = pluginOptions;
+    }
+}

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDoc.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDoc.java
@@ -2,7 +2,6 @@ package org.interestinglab.waterdrop.docutils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by gaoyingju on 17/09/2017.
@@ -19,14 +18,47 @@ public class PluginDoc {
 
     public static class PluginOption {
 
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        public void setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        public enum Required {
+            YES("yes"),
+            NO("no")
+            ;
+
+            private final String text;
+
+            /**
+             * @param text
+             */
+            Required(final String text) {
+                this.text = text;
+            }
+
+            /* (non-Javadoc)
+             * @see java.lang.Enum#toString()
+             */
+            @Override
+            public String toString() {
+                return text;
+            }
+        }
+
         private String optionType;
         private String optionName;
-        private String optionDesc;
-        private boolean required = true;
+        private String optionDesc = "";
+        private Required required = Required.YES;
+        private String defaultValue = "-";
 
-        public PluginOption(final String optionType, final String optionName, final String optionDesc) {
+        public PluginOption(final String optionType, final String optionName, final Required required, final String optionDesc) {
             this.optionType = optionType;
             this.optionName = optionName;
+            this.required = required;
             this.optionDesc = optionDesc;
         }
 
@@ -54,18 +86,14 @@ public class PluginDoc {
             this.optionDesc = optionDesc;
         }
 
-        public boolean isRequired() {
+        public Required getRequired() {
             return required;
         }
 
-        public void setRequired(boolean required) {
+        public void setRequired(Required required) {
             this.required = required;
         }
     }
-
-//    public static PluginOption newPluginOption(final String optionType, final String optionName, final String optionDesc) {
-//        return new PluginOption(optionType, optionName, optionDesc);
-//    }
 
     public String getPluginGroup() {
         return pluginGroup;

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDoc.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDoc.java
@@ -18,13 +18,11 @@ public class PluginDoc {
 
     public static class PluginOption {
 
-        public String getDefaultValue() {
-            return defaultValue;
-        }
-
-        public void setDefaultValue(String defaultValue) {
-            this.defaultValue = defaultValue;
-        }
+        private String optionType;
+        private String optionName;
+        private String optionDesc = "";
+        private Required required = Required.YES;
+        private String defaultValue = "-";
 
         public enum Required {
             YES("yes"),
@@ -48,12 +46,6 @@ public class PluginDoc {
                 return text;
             }
         }
-
-        private String optionType;
-        private String optionName;
-        private String optionDesc = "";
-        private Required required = Required.YES;
-        private String defaultValue = "-";
 
         public PluginOption(final String optionType, final String optionName, final Required required, final String optionDesc) {
             this.optionType = optionType;
@@ -92,6 +84,14 @@ public class PluginDoc {
 
         public void setRequired(Required required) {
             this.required = required;
+        }
+
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        public void setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
         }
     }
 

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocCommand.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocCommand.java
@@ -1,0 +1,26 @@
+package org.interestinglab.waterdrop.docutils;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.interestinglab.waterdrop.configparser.*;
+
+/**
+ * Created by gaoyingju on 16/09/2017.
+ */
+public class PluginDocCommand {
+
+    public static void main(String[] args) throws Exception {
+
+        CharStream charStream = CharStreams.fromFileName(args[0]);
+        PluginDocLexer lexer = new PluginDocLexer(charStream);
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        PluginDocParser parser = new PluginDocParser(tokens);
+
+        PluginDocParser.WaterdropPluginContext context = parser.waterdropPlugin();
+        PluginDocVisitor<String> visitor = new PluginDocMarkdownRender();
+        String text = visitor.visit(context);
+
+        System.out.println("Rendered Plugin Doc: \n" + text);
+    }
+}

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
@@ -103,14 +103,14 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
             return ctx.OUTPUT().getText();
         }
 
-        throw new RuntimeException("invalid plugin group in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginGroup - 1]);
+        throw new PluginDocRuntimeException("invalid plugin group in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginGroup - 1]);
     }
 
     @Override
     public String visitPluginName(PluginDocParser.PluginNameContext ctx) {
 
         if (ctx.IDENTIFIER() == null) {
-            throw new RuntimeException("invalid plugin name in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginName - 1]);
+            throw new PluginDocRuntimeException("invalid plugin name in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginName - 1]);
         }
 
         return ctx.IDENTIFIER().getText();
@@ -120,7 +120,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginDesc(PluginDocParser.PluginDescContext ctx) {
 
         if (ctx.IDENTIFIER() == null && ctx.TEXT() == null) {
-            throw new RuntimeException("invalid plugin description in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginDesc - 1]);
+            throw new PluginDocRuntimeException("invalid plugin description in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginDesc - 1]);
         }
 
         TerminalNode node = ctx.IDENTIFIER();
@@ -136,7 +136,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginAuthor(PluginDocParser.PluginAuthorContext ctx) {
 
         if (ctx.TEXT() == null && ctx.IDENTIFIER() == null) {
-            throw new RuntimeException("invalid plugin author in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginAuthor - 1]);
+            throw new PluginDocRuntimeException("invalid plugin author in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginAuthor - 1]);
         }
 
         TerminalNode node = ctx.TEXT();
@@ -152,7 +152,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginHomepage(PluginDocParser.PluginHomepageContext ctx) {
 
         if (ctx.URL() == null) {
-            throw new RuntimeException("invalid plugin homepage in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginHomepage - 1]);
+            throw new PluginDocRuntimeException("invalid plugin homepage in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginHomepage - 1]);
         }
 
         return ctx.URL().getText();
@@ -162,7 +162,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginVersion(PluginDocParser.PluginVersionContext ctx) {
 
         if (ctx.VERSION_NUMBER() == null) {
-            throw new RuntimeException("invalid plugin version in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginVersion - 1]);
+            throw new PluginDocRuntimeException("invalid plugin version in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginVersion - 1]);
         }
 
         return ctx.VERSION_NUMBER().getText();
@@ -172,7 +172,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginOption(PluginDocParser.PluginOptionContext ctx) {
 
         if (ctx.optionType() == null || ctx.optionName() == null || ctx.optionRequired() == null) {
-            throw new RuntimeException("optionType, optionName, optionRequired shoud be specified");
+            throw new PluginDocRuntimeException("optionType, optionName, optionRequired shoud be specified");
         }
 
         final String optionType = visit(ctx.optionType());
@@ -203,7 +203,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitOptionType(PluginDocParser.OptionTypeContext ctx) {
 
         if (ctx.getText() == null) {
-            throw new RuntimeException("invalid option type in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+            throw new PluginDocRuntimeException("invalid option type in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
         }
 
         return ctx.getText();
@@ -213,7 +213,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitOptionName(PluginDocParser.OptionNameContext ctx) {
 
         if (ctx.IDENTIFIER() == null) {
-            throw new RuntimeException("invalid option name in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+            throw new PluginDocRuntimeException("invalid option name in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
         }
 
         return ctx.IDENTIFIER().getText();
@@ -223,7 +223,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitOptionDefaultValue(PluginDocParser.OptionDefaultValueContext ctx) {
 
         if (ctx.TEXT() == null) {
-            throw new RuntimeException("invalid option default value in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+            throw new PluginDocRuntimeException("invalid option default value in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
         }
 
         final String unquoted = StringUtils.strip(ctx.TEXT().getText(), "\"'");
@@ -242,7 +242,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
             return PluginDoc.PluginOption.Required.NO.toString();
 
         } else {
-            throw new RuntimeException("invalid option required in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+            throw new PluginDocRuntimeException("invalid option required in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
         }
     }
 

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
@@ -40,6 +40,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
 
         // append markdown table
         str.append("| name | type | required | default value |\n");
+        str.append("| --- | --- | --- | --- |\n");
         for (PluginDoc.PluginOption option : pluginDoc.getPluginOptions()) {
             str.append(String.format("| %s | %s | %s | %s |\n",
                     option.getOptionName(), option.getOptionType(), option.isRequired(), "null"));

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
@@ -190,8 +190,12 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
         }
 
         PluginDoc.PluginOption option = new PluginDoc.PluginOption(optionType, optionName, required, optionDesc);
-        pluginDoc.getPluginOptions().add(option);
 
+        if (required == PluginDoc.PluginOption.Required.NO && ctx.optionDefaultValue() != null) {
+            option.setDefaultValue(visit(ctx.optionDefaultValue()));
+        }
+
+        pluginDoc.getPluginOptions().add(option);
         return null;
     }
 
@@ -213,6 +217,17 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
         }
 
         return ctx.IDENTIFIER().getText();
+    }
+
+    @Override
+    public String visitOptionDefaultValue(PluginDocParser.OptionDefaultValueContext ctx) {
+
+        if (ctx.TEXT() == null) {
+            throw new RuntimeException("invalid option default value in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+        }
+
+        final String unquoted = StringUtils.strip(ctx.TEXT().getText(), "\"'");
+        return unquoted;
     }
 
     @Override

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
@@ -103,14 +103,14 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
             return ctx.OUTPUT().getText();
         }
 
-        throw new RuntimeException("visitPluginGroup 1");
+        throw new RuntimeException("invalid plugin group in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginGroup - 1]);
     }
 
     @Override
     public String visitPluginName(PluginDocParser.PluginNameContext ctx) {
 
         if (ctx.IDENTIFIER() == null) {
-            throw new RuntimeException("visitPluginName 1");
+            throw new RuntimeException("invalid plugin name in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginName - 1]);
         }
 
         return ctx.IDENTIFIER().getText();
@@ -120,7 +120,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginDesc(PluginDocParser.PluginDescContext ctx) {
 
         if (ctx.IDENTIFIER() == null && ctx.TEXT() == null) {
-            throw new RuntimeException("visitPluginDesc 1");
+            throw new RuntimeException("invalid plugin description in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginDesc - 1]);
         }
 
         TerminalNode node = ctx.IDENTIFIER();
@@ -136,7 +136,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginAuthor(PluginDocParser.PluginAuthorContext ctx) {
 
         if (ctx.TEXT() == null && ctx.IDENTIFIER() == null) {
-            throw new RuntimeException("visitPluginAuthor 1");
+            throw new RuntimeException("invalid plugin author in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginAuthor - 1]);
         }
 
         TerminalNode node = ctx.TEXT();
@@ -152,7 +152,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginHomepage(PluginDocParser.PluginHomepageContext ctx) {
 
         if (ctx.URL() == null) {
-            throw new RuntimeException("visitPluginHomepage 1");
+            throw new RuntimeException("invalid plugin homepage in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginHomepage - 1]);
         }
 
         return ctx.URL().getText();
@@ -162,7 +162,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginVersion(PluginDocParser.PluginVersionContext ctx) {
 
         if (ctx.VERSION_NUMBER() == null) {
-            throw new RuntimeException("visitPluginVersion 1");
+            throw new RuntimeException("invalid plugin version in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginVersion - 1]);
         }
 
         return ctx.VERSION_NUMBER().getText();
@@ -172,7 +172,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     public String visitPluginOption(PluginDocParser.PluginOptionContext ctx) {
 
         if (ctx.optionType() == null || ctx.optionName() == null || ctx.optionRequired() == null) {
-            throw new RuntimeException("visitPluginOption 1");
+            throw new RuntimeException("optionType, optionName, optionRequired shoud be specified");
         }
 
         final String optionType = visit(ctx.optionType());

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
@@ -1,0 +1,221 @@
+package org.interestinglab.waterdrop.docutils;
+
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.commons.lang.StringUtils;
+import org.interestinglab.waterdrop.configparser.PluginDocBaseVisitor;
+import org.interestinglab.waterdrop.configparser.PluginDocLexer;
+import org.interestinglab.waterdrop.configparser.PluginDocParser;
+
+import java.util.Collections;
+import java.util.Comparator;
+
+
+/**
+ * Created by gaoyingju on 16/09/2017.
+ */
+public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
+
+    private PluginDoc pluginDoc = new PluginDoc();
+
+    private String buildMarkdown() {
+
+        StringBuilder str = new StringBuilder();
+
+        str.append("## " + pluginDoc.getPluginGroup() + " plugin : " + pluginDoc.getPluginName() + "\n\n");
+        str.append("* Author: " + pluginDoc.getPluginAuthor() + "\n");
+        str.append("* Homepage: " + pluginDoc.getPluginHomepage() + "\n");
+        str.append("* Version: " + pluginDoc.getPluginVersion() + "\n");
+        str.append("\n");
+        str.append("### Description\n\n");
+        str.append(pluginDoc.getPluginDesc() + "\n");
+        str.append("\n");
+        str.append("### Options\n\n");
+
+        Collections.sort(pluginDoc.getPluginOptions(), new Comparator<PluginDoc.PluginOption>() {
+            @Override
+            public int compare(PluginDoc.PluginOption o1, PluginDoc.PluginOption o2) {
+                return o1.getOptionName().compareTo(o2.getOptionName());
+            }
+        });
+
+        // append markdown table
+        str.append("| name | type | required | default value |\n");
+        for (PluginDoc.PluginOption option : pluginDoc.getPluginOptions()) {
+            str.append(String.format("| %s | %s | %s | %s |\n",
+                    option.getOptionName(), option.getOptionType(), option.isRequired(), "null"));
+        }
+
+        // append option details
+        for (PluginDoc.PluginOption option : pluginDoc.getPluginOptions()) {
+            str.append("\n");
+            str.append("##### " + option.getOptionName() + " [" + option.getOptionType() + "]" + "\n\n");
+            str.append(option.getOptionDesc() + "\n");
+        }
+
+        return str.toString();
+    }
+
+    @Override
+    public String visitWaterdropPlugin(PluginDocParser.WaterdropPluginContext ctx) {
+
+        visitChildren(ctx);
+        return buildMarkdown();
+    }
+
+    @Override
+    public String visitDefinition(PluginDocParser.DefinitionContext ctx) {
+
+        if (ctx.pluginGroup() != null) {
+
+            pluginDoc.setPluginGroup(visit(ctx.pluginGroup()));
+        } else if (ctx.pluginName() != null) {
+
+            pluginDoc.setPluginName(visit(ctx.pluginName()));
+        } else if (ctx.pluginDesc() != null) {
+
+            pluginDoc.setPluginDesc(visit(ctx.pluginDesc()));
+        } else if (ctx.pluginAuthor() != null) {
+
+            pluginDoc.setPluginAuthor(visit(ctx.pluginAuthor()));
+        } else if (ctx.pluginHomepage() != null) {
+
+            pluginDoc.setPluginHomepage(visit(ctx.pluginHomepage()));
+        } else if (ctx.pluginVersion() != null) {
+
+            pluginDoc.setPluginVersion(visit(ctx.pluginVersion()));
+        } else if (ctx.pluginOption() != null) {
+
+            visit(ctx.pluginOption());
+        }
+
+        return null;
+    }
+
+    @Override
+    public String visitPluginGroup(PluginDocParser.PluginGroupContext ctx) {
+
+        if (ctx.INPUT() != null) {
+            return ctx.INPUT().getText();
+        } else if (ctx.FILTER() != null) {
+            return ctx.FILTER().getText();
+        } else if (ctx.OUTPUT() != null) {
+            return ctx.OUTPUT().getText();
+        }
+
+        throw new RuntimeException("visitPluginGroup 1");
+    }
+
+    @Override
+    public String visitPluginName(PluginDocParser.PluginNameContext ctx) {
+
+        if (ctx.IDENTIFIER() == null) {
+            throw new RuntimeException("visitPluginName 1");
+        }
+
+        return ctx.IDENTIFIER().getText();
+    }
+
+    @Override
+    public String visitPluginDesc(PluginDocParser.PluginDescContext ctx) {
+
+        if (ctx.IDENTIFIER() == null && ctx.TEXT() == null) {
+            throw new RuntimeException("visitPluginDesc 1");
+        }
+
+        TerminalNode node = ctx.IDENTIFIER();
+        if (node == null) {
+            node = ctx.TEXT();
+        }
+
+        final String unquoted = StringUtils.strip(node.getText(), "\"'");
+        return unquoted;
+    }
+
+    @Override
+    public String visitPluginAuthor(PluginDocParser.PluginAuthorContext ctx) {
+
+        if (ctx.TEXT() == null && ctx.IDENTIFIER() == null) {
+            throw new RuntimeException("visitPluginAuthor 1");
+        }
+
+        TerminalNode node = ctx.TEXT();
+        if (node == null) {
+            node = ctx.IDENTIFIER();
+        }
+
+        final String unquoted = StringUtils.strip(node.getText(), "\"'");
+        return unquoted;
+    }
+
+    @Override
+    public String visitPluginHomepage(PluginDocParser.PluginHomepageContext ctx) {
+
+        if (ctx.URL() == null) {
+            throw new RuntimeException("visitPluginHomepage 1");
+        }
+
+        return ctx.URL().getText();
+    }
+
+    @Override
+    public String visitPluginVersion(PluginDocParser.PluginVersionContext ctx) {
+
+        if (ctx.VERSION_NUMBER() == null) {
+            throw new RuntimeException("visitPluginVersion 1");
+        }
+
+        return ctx.VERSION_NUMBER().getText();
+    }
+
+    @Override
+    public String visitPluginOption(PluginDocParser.PluginOptionContext ctx) {
+
+        if (ctx.optionType() == null || ctx.optionName() == null) {
+            throw new RuntimeException("visitPluginOption 1");
+        }
+
+        final String optionType = visit(ctx.optionType());
+        final String optionName = visit(ctx.optionName());
+        String optionDesc = "";
+        if (ctx.optionDesc() != null) {
+            optionDesc = visit(ctx.optionDesc());
+        }
+
+        PluginDoc.PluginOption option = new PluginDoc.PluginOption(optionType, optionName, optionDesc);
+        pluginDoc.getPluginOptions().add(option);
+
+        return null;
+    }
+
+    @Override
+    public String visitOptionType(PluginDocParser.OptionTypeContext ctx) {
+
+        if (ctx.getText() == null) {
+            throw new RuntimeException("invalid option type in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+        }
+
+        return ctx.getText();
+    }
+
+    @Override
+    public String visitOptionName(PluginDocParser.OptionNameContext ctx) {
+
+        if (ctx.IDENTIFIER() == null) {
+            throw new RuntimeException("invalid option name in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+        }
+
+        return ctx.IDENTIFIER().getText();
+    }
+
+    @Override
+    public String visitOptionDesc(PluginDocParser.OptionDescContext ctx) {
+
+        if (ctx.TEXT() != null) {
+
+            final String unquoted = StringUtils.strip(ctx.TEXT().getText(), "\"'");
+            return unquoted;
+        }
+
+        return "";
+    }
+}

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocMarkdownRender.java
@@ -43,7 +43,7 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
         str.append("| --- | --- | --- | --- |\n");
         for (PluginDoc.PluginOption option : pluginDoc.getPluginOptions()) {
             str.append(String.format("| %s | %s | %s | %s |\n",
-                    option.getOptionName(), option.getOptionType(), option.isRequired(), "null"));
+                    option.getOptionName(), option.getOptionType(), option.getRequired().toString(), option.getDefaultValue()));
         }
 
         // append option details
@@ -171,18 +171,25 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
     @Override
     public String visitPluginOption(PluginDocParser.PluginOptionContext ctx) {
 
-        if (ctx.optionType() == null || ctx.optionName() == null) {
+        if (ctx.optionType() == null || ctx.optionName() == null || ctx.optionRequired() == null) {
             throw new RuntimeException("visitPluginOption 1");
         }
 
         final String optionType = visit(ctx.optionType());
         final String optionName = visit(ctx.optionName());
+        final String optionRequired = visit(ctx.optionRequired());
+
+        PluginDoc.PluginOption.Required required = PluginDoc.PluginOption.Required.YES;
+        if (optionRequired.equals(PluginDoc.PluginOption.Required.NO.toString())) {
+            required = PluginDoc.PluginOption.Required.NO;
+        }
+
         String optionDesc = "";
         if (ctx.optionDesc() != null) {
             optionDesc = visit(ctx.optionDesc());
         }
 
-        PluginDoc.PluginOption option = new PluginDoc.PluginOption(optionType, optionName, optionDesc);
+        PluginDoc.PluginOption option = new PluginDoc.PluginOption(optionType, optionName, required, optionDesc);
         pluginDoc.getPluginOptions().add(option);
 
         return null;
@@ -206,6 +213,22 @@ public class PluginDocMarkdownRender extends PluginDocBaseVisitor<String> {
         }
 
         return ctx.IDENTIFIER().getText();
+    }
+
+    @Override
+    public String visitOptionRequired(PluginDocParser.OptionRequiredContext ctx) {
+
+        if (ctx.YES() != null) {
+
+            return PluginDoc.PluginOption.Required.YES.toString();
+
+        } else if (ctx.NO() != null) {
+
+            return PluginDoc.PluginOption.Required.NO.toString();
+
+        } else {
+            throw new RuntimeException("invalid option required in @" + PluginDocLexer.ruleNames[PluginDocLexer.PluginOption - 1]);
+        }
     }
 
     @Override

--- a/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocRuntimeException.java
+++ b/src/main/java/org/interestinglab/waterdrop/docutils/PluginDocRuntimeException.java
@@ -1,0 +1,23 @@
+package org.interestinglab.waterdrop.docutils;
+
+/**
+ * Created by gaoyingju on 18/09/2017.
+ */
+public class PluginDocRuntimeException extends RuntimeException {
+
+    public PluginDocRuntimeException() {
+        super();
+    }
+
+    public PluginDocRuntimeException(String message) {
+        super(message);
+    }
+
+    public PluginDocRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PluginDocRuntimeException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Plugin document自动生成功能：

功能描述：根据plugin开发者定义的*.docs文件，自动生成markdown文件

优点：

* plugin document 定义方式相同，展现格式统一，可程序解析。

示例：执行命令：

```
sbt "run-main org.interestinglab.waterdrop.docutils.PluginDocCommand src/main/antlr4/PluginDocExample.docs"
```

PluginDocExample.docs内容：

```
@waterdropPlugin
@pluginGroup input
@pluginName kafka
@pluginDesc "get message from kafka"
@pluginAuthor garyelephant
@pluginHomepage https://interestinglab.github.io/waterdrop
@pluginVersion 1.2.3

@pluginOption array topics yes "a list of topics to consume"
@pluginOption string consumer.bootstrap.servers yes "kafka broker list"
@pluginOption string consumer.group.id yes "consumer group id"
@pluginOption number consumer.num.consumer.fetchers="2" no
```

---

输出如下markdown内容：

## input plugin : kafka

* Author: garyelephant
* Homepage: https://interestinglab.github.io/waterdrop
* Version: 1.2.3

### Description

get message from kafka

### Options

| name | type | required | default value |
| --- | --- | --- | --- |
| consumer.bootstrap.servers | string | yes | - |
| consumer.group.id | string | yes | - |
| consumer.num.consumer.fetchers | number | no | 2 |
| topics | array | yes | - |

##### consumer.bootstrap.servers [string]

kafka broker list

##### consumer.group.id [string]

consumer group id

##### consumer.num.consumer.fetchers [number]



##### topics [array]

a list of topics to consume
