### PR TITLE
Update filter json

### DIFF
--- a/src/main/scala/org/interestinglab/waterdrop/filter/Json.scala
+++ b/src/main/scala/org/interestinglab/waterdrop/filter/Json.scala
@@ -57,4 +57,5 @@ class Json(var conf: Config) extends BaseFilter(conf) {
 
 object Json {
   val ROOT = "__root__"
+  val TMP = "__tmp__"
 }


### PR DESCRIPTION
更新了当`target_filter` 为 __root__时的处理逻辑，相比之前的逻辑有以下几点优势

1. 无需重新创建DataFrame，能节省一定性能
2. 无法编写`StructField`，减少处理流程编写的难度
2. 复用`split`方法，代码更加简洁。