### PR TITLE
Garyelephant.variables substitution

### DIFF
--- a/bin/start-waterdrop.sh
+++ b/bin/start-waterdrop.sh
@@ -23,6 +23,13 @@ while (( "$#" )); do
       shift 2
       ;;
 
+    -i|--variable)
+      variable=$2
+      java_property_value="-D${variable}"
+      variables_substitution="${java_property_value} ${variables_substitution}"
+      shift 2
+      ;;
+
     --) # end argument parsing
       shift
       break
@@ -89,6 +96,10 @@ assemblyJarName=$(find ${LIB_DIR} -name Waterdrop-*.jar)
 
 source ${CONF_DIR}/waterdrop-env.sh
 
+string_trim() {
+    echo $1 | awk '{$1=$1;print}'
+}
+
 ## get spark conf from config file and specify them in spark-submit
 function get_spark_conf {
     spark_conf=$(java -cp ${assemblyJarName} io.github.interestinglab.waterdrop.config.ExposeSparkConf ${CONFIG_FILE})
@@ -100,6 +111,21 @@ function get_spark_conf {
 }
 
 sparkconf=$(get_spark_conf)
+
+# Spark Driver Options
+variables_substitution=$(string_trim "${variables_substitution}")
+driverJavaOpts=""
+executorJavaOpts=""
+clientModeDriverJavaOpts=""
+if [ ! -z "${variables_substitution}" ]; then
+  driverJavaOpts="--conf \"spark.driver.extraJavaOptions=${variables_substitution}\""
+  executorJavaOpts="--conf \"spark.executor.extraJavaOptions=${variables_substitution}\""
+  # in local, client mode, driverJavaOpts can not work, we must use --driver-java-options
+  clientModeDriverJavaOpts="--driver-java-options \"${variables_substitution}\""
+fi
+
+
+sparkconf="${sparkconf} ${driverJavaOpts} ${executorJavaOpts} ${clientModeDriverJavaOpts}"
 
 echo "[INFO] spark conf: ${sparkconf}"
 

--- a/bin/start-waterdrop.sh
+++ b/bin/start-waterdrop.sh
@@ -110,21 +110,19 @@ function get_spark_conf {
 
 sparkconf=$(get_spark_conf)
 
+echo "[INFO] spark conf: ${sparkconf}"
+
 # Spark Driver Options
 variables_substitution=$(string_trim "${variables_substitution}")
 driverJavaOpts=""
 executorJavaOpts=""
 clientModeDriverJavaOpts=""
 if [ ! -z "${variables_substitution}" ]; then
-  driverJavaOpts="--conf \"spark.driver.extraJavaOptions=${variables_substitution}\""
-  executorJavaOpts="--conf \"spark.executor.extraJavaOptions=${variables_substitution}\""
+  driverJavaOpts="${variables_substitution}"
+  executorJavaOpts="${variables_substitution}"
   # in local, client mode, driverJavaOpts can not work, we must use --driver-java-options
-  clientModeDriverJavaOpts="--driver-java-options \"${variables_substitution}\""
+  clientModeDriverJavaOpts="${variables_substitution}"
 fi
-
-sparkconf="${sparkconf} ${driverJavaOpts} ${executorJavaOpts} ${clientModeDriverJavaOpts}"
-
-echo "[INFO] spark conf: ${sparkconf}"
 
 
 ## compress plugins.tar.gz in cluster mode
@@ -151,6 +149,9 @@ exec ${SPARK_HOME}/bin/spark-submit --class io.github.interestinglab.waterdrop.W
     --name $(getAppName ${CONFIG_FILE}) \
     --master ${MASTER} \
     --deploy-mode ${DEPLOY_MODE} \
+    --driver-java-options "${clientModeDriverJavaOpts}" \
+    --conf spark.executor.extraJavaOptions="${executorJavaOpts}" \
+    --conf spark.driver.extraJavaOptions="${driverJavaOpts}" \
     ${sparkconf} \
     ${JarDepOpts} \
     ${FilesDepOpts} \

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/CommandLineUtils.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/CommandLineUtils.scala
@@ -18,5 +18,6 @@ object CommandLineUtils {
     opt[String]('m', "master")
       .required()
       .text("spark master")
+    opt[String]('i', "variable").optional().text("variable substitution, such as -i city=beijing, or -i date=20190318")
   }
 }

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/CommandLineUtils.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/CommandLineUtils.scala
@@ -18,6 +18,9 @@ object CommandLineUtils {
     opt[String]('m', "master")
       .required()
       .text("spark master")
-    opt[String]('i', "variable").optional().text("variable substitution, such as -i city=beijing, or -i date=20190318")
+    opt[String]('i', "variable")
+      .optional()
+      .text("variable substitution, such as -i city=beijing, or -i date=20190318")
+      .maxOccurs(Integer.MAX_VALUE)
   }
 }

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/filter/Sql.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/filter/Sql.scala
@@ -25,7 +25,8 @@ class Sql extends BaseFilter {
 
   override def checkConfig(): (Boolean, String) = {
     conf.hasPath("table_name") && conf.hasPath("sql") match {
-      case true => checkSQLSyntax(conf.getString("sql"))
+      case true => (true, "")
+      // case true => checkSQLSyntax(conf.getString("sql"))
       case false => (false, "please specify [table_name] and [sql]")
     }
   }


### PR DESCRIPTION
* enhanced the useage of variable substitution:

```
./bin/start-waterdrop.sh -c ./config/variable-substitution.conf.template -e cluster -m yarn -i city2=shanghai -i dt=20190319

./bin/start-waterdrop.sh -c ./config/variable-substitution.conf.template -e client -m yarn -i city2=shanghai -i dt=20190319

./bin/start-waterdrop.sh -c ./config/variable-substitution.conf.template -e client -m local[2] -i city2=shanghai -i dt=20190319
```

option `-i` is same as  `--variable` in  variable substitution.
