### PR TITLE
make jdbc output for structstreaming work

### DIFF
--- a/waterdrop-core/src/main/java/io/github/interestinglab/waterdrop/utils/JdbcConnectionPoll.java
+++ b/waterdrop-core/src/main/java/io/github/interestinglab/waterdrop/utils/JdbcConnectionPoll.java
@@ -13,7 +13,7 @@ public class JdbcConnectionPoll implements Serializable {
 
     private static JdbcConnectionPoll poll;
 
-    private transient DruidDataSource dataSource;
+    private DruidDataSource dataSource;
 
     private JdbcConnectionPoll(Properties properties) throws Exception {
         dataSource = (DruidDataSource) DruidDataSourceFactory.createDataSource(properties);

--- a/waterdrop-core/src/main/java/io/github/interestinglab/waterdrop/utils/JdbcConnectionPoll.java
+++ b/waterdrop-core/src/main/java/io/github/interestinglab/waterdrop/utils/JdbcConnectionPoll.java
@@ -13,7 +13,7 @@ public class JdbcConnectionPoll implements Serializable {
 
     private static JdbcConnectionPoll poll;
 
-    private  DruidDataSource dataSource;
+    private transient DruidDataSource dataSource;
 
     private JdbcConnectionPoll(Properties properties) throws Exception {
         dataSource = (DruidDataSource) DruidDataSourceFactory.createDataSource(properties);
@@ -31,7 +31,6 @@ public class JdbcConnectionPoll implements Serializable {
     }
 
     public Connection getConnection() throws SQLException {
-
        return dataSource.getConnection();
     }
 


### PR DESCRIPTION
fix structured-streaming jdbc output exception:
```
Caused by: org.apache.spark.SparkException: Task not serializable
	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:403)
	at org.apache.spark.util.ClosureCleaner$.org$apache$spark$util$ClosureCleaner$$clean(ClosureCleaner.scala:393)
	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:162)
	at org.apache.spark.SparkContext.clean(SparkContext.scala:2326)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2056)
	at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.doExecute(WriteToDataSourceV2Exec.scala:64)
	... 35 more
Caused by: java.io.NotSerializableException: java.io.PrintWriter
Serialization stack:
	- object not serializable (class: java.io.PrintWriter, value: java.io.PrintWriter@4aa33955)
	- field (class: com.alibaba.druid.pool.DruidAbstractDataSource, name: logWriter, type: class java.io.PrintWriter)
	- object (class com.alibaba.druid.pool.DruidDataSource, {
	CreateTime:"2019-08-12 22:00:34",
```