### PR TITLE
fixed v2 spark cluster mode plugins.tar.gz error

### DIFF
--- a/waterdrop-core/src/main/java/io/github/interestinglab/waterdrop/utils/CompressionUtils.java
+++ b/waterdrop-core/src/main/java/io/github/interestinglab/waterdrop/utils/CompressionUtils.java
@@ -1,0 +1,93 @@
+package io.github.interestinglab.waterdrop.utils;
+
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.utils.IOUtils;
+import org.apache.log4j.Logger;
+
+import java.io.*;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+
+public class CompressionUtils {
+
+    private static final Logger logger = Logger.getLogger(CompressionUtils.class);
+
+    /** Untar an input file into an output file.
+
+     * The output file is created in the output folder, having the same name
+     * as the input file, minus the '.tar' extension.
+     *
+     * @param inputFile     the input .tar file
+     * @param outputDir     the output directory file.
+     * @throws IOException
+     * @throws FileNotFoundException
+     *
+     * @return  The {@link List} of {@link File}s with the untared content.
+     * @throws ArchiveException
+     */
+    public static List<File> unTar(final File inputFile, final File outputDir) throws FileNotFoundException, IOException, ArchiveException {
+
+        logger.info(String.format("Untaring %s to dir %s.", inputFile.getAbsolutePath(), outputDir.getAbsolutePath()));
+
+        final List<File> untaredFiles = new LinkedList<File>();
+        final InputStream is = new FileInputStream(inputFile);
+        final TarArchiveInputStream debInputStream = (TarArchiveInputStream) new ArchiveStreamFactory().createArchiveInputStream("tar", is);
+        TarArchiveEntry entry = null;
+        while ((entry = (TarArchiveEntry)debInputStream.getNextEntry()) != null) {
+            final File outputFile = new File(outputDir, entry.getName());
+            if (entry.isDirectory()) {
+                logger.info(String.format("Attempting to write output directory %s.", outputFile.getAbsolutePath()));
+                if (!outputFile.exists()) {
+                    logger.info(String.format("Attempting to create output directory %s.", outputFile.getAbsolutePath()));
+                    if (!outputFile.mkdirs()) {
+                        throw new IllegalStateException(String.format("Couldn't create directory %s.", outputFile.getAbsolutePath()));
+                    }
+                }
+            } else {
+                logger.info(String.format("Creating output file %s.", outputFile.getAbsolutePath()));
+                final OutputStream outputFileStream = new FileOutputStream(outputFile);
+                IOUtils.copy(debInputStream, outputFileStream);
+                outputFileStream.close();
+            }
+            untaredFiles.add(outputFile);
+        }
+        debInputStream.close();
+
+        return untaredFiles;
+    }
+
+    /**
+     * Ungzip an input file into an output file.
+     * <p>
+     * The output file is created in the output folder, having the same name
+     * as the input file, minus the '.gz' extension.
+     *
+     * @param inputFile     the input .gz file
+     * @param outputDir     the output directory file.
+     * @throws IOException
+     * @throws FileNotFoundException
+     *
+     * @return  The {@File} with the ungzipped content.
+     */
+    public static File unGzip(final File inputFile, final File outputDir) throws FileNotFoundException, IOException {
+
+        logger.info(String.format("Ungzipping %s to dir %s.", inputFile.getAbsolutePath(), outputDir.getAbsolutePath()));
+
+        final File outputFile = new File(outputDir, inputFile.getName().substring(0, inputFile.getName().length() - 3));
+
+        final GZIPInputStream in = new GZIPInputStream(new FileInputStream(inputFile));
+        final FileOutputStream out = new FileOutputStream(outputFile);
+
+        IOUtils.copy(in, out);
+
+        in.close();
+        out.close();
+
+        return outputFile;
+    }
+
+}


### PR DESCRIPTION
v2 spark json解析插件在cluster模式下无法找到json  schema文件，原因是wd v2没有像v1那样针对cluster上传的plugins文件做过处理，此pr修复了。