### PR TITLE
Feature: add spark sink hbase plugin

### DIFF
--- a/plugin-spark-phoenix-core/pom.xml
+++ b/plugin-spark-phoenix-core/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.apache.phoenix</groupId>
             <artifactId>phoenix-spark</artifactId>
-            <version>4.14.0-HBase-1.2</version>
+            <version>5.0.0-HBase-2.0</version>
         </dependency>
 
         <dependency>

--- a/plugin-spark-sink-hbase/pom.xml
+++ b/plugin-spark-sink-hbase/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>waterdop</artifactId>
+    <groupId>io.github.interestinglab.waterdrop</groupId>
+    <version>2.0.4</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>plugin-spark-sink-hbase</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.github.interestinglab.waterdrop</groupId>
+      <artifactId>waterdrop-spark-api</artifactId>
+      <version>2.0.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.11</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_2.11</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_2.11</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hbase.connectors.spark</groupId>
+      <artifactId>hbase-spark</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+      <!-- maven-source-plugin has to be here to add sources for scala code, although -->
+      <!-- see https://stackoverflow.com/a/37174571/1145750 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin-spark-sink-hbase/src/main/resources/META-INF/services/io.github.interestinglab.waterdrop.spark.BaseSparkSink
+++ b/plugin-spark-sink-hbase/src/main/resources/META-INF/services/io.github.interestinglab.waterdrop.spark.BaseSparkSink
@@ -1,0 +1,1 @@
+io.github.interestinglab.waterdrop.spark.sink.Hbase

--- a/plugin-spark-sink-hbase/src/main/scala/io/github/interestinglab/waterdrop/spark/sink/Hbase.scala
+++ b/plugin-spark-sink-hbase/src/main/scala/io/github/interestinglab/waterdrop/spark/sink/Hbase.scala
@@ -1,0 +1,161 @@
+package io.github.interestinglab.waterdrop.spark.sink
+
+import io.github.interestinglab.waterdrop.common.config.CheckResult
+import io.github.interestinglab.waterdrop.config.{Config, ConfigFactory}
+import io.github.interestinglab.waterdrop.spark.SparkEnvironment
+import io.github.interestinglab.waterdrop.spark.batch.SparkBatchSink
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory}
+import org.apache.hadoop.hbase.spark.datasources.HBaseTableCatalog
+import org.apache.hadoop.hbase.spark.{ByteArrayWrapper, FamiliesQualifiersValues, HBaseContext}
+import org.apache.hadoop.hbase.tool.LoadIncrementalHFiles
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.{HBaseConfiguration, TableName, _}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.{Dataset, Row}
+
+import scala.collection.JavaConversions._
+import scala.util.control.Breaks._
+
+class Hbase extends SparkBatchSink with Logging {
+
+  @transient var hbaseConf: Configuration = _
+  var hbaseContext: HBaseContext = _
+  var hbasePrefix = "hbase."
+
+  /**
+   * Set Config.
+   * */
+  override def setConfig(config: Config): Unit = {
+    this.config = config
+  }
+
+  /**
+   * Get Config.
+   * */
+  override def getConfig(): Config = {
+    this.config
+  }
+
+  override def checkConfig(): CheckResult = {
+    val requiredOptions = List("hbase.zookeeper.quorum", "catalog", "staging_dir")
+    val nonExistsOptions = requiredOptions.map(optionName => (optionName, config.hasPath(optionName))).filter { p =>
+      val (optionName, exists) = p
+      !exists
+    }
+    if (nonExistsOptions.length != 0) {
+      new CheckResult(false, "please specify " + nonExistsOptions.map("[" + _._1 + "]").mkString(", ") + " as non-empty string")
+    } else {
+      new CheckResult(true, "")
+    }
+  }
+
+  override def prepare(env: SparkEnvironment): Unit = {
+    val defaultConfig = ConfigFactory.parseMap(
+      Map(
+        "save_mode" -> HbaseSaveMode.Append.toString.toLowerCase
+      )
+    )
+
+    config = config.withFallback(defaultConfig)
+    hbaseConf = HBaseConfiguration.create(env.getSparkSession.sessionState.newHadoopConf())
+    config
+      .entrySet()
+      .foreach(entry => {
+        val key = entry.getKey
+        if (key.startsWith(hbasePrefix)) {
+          val value = String.valueOf(entry.getValue.unwrapped())
+          hbaseConf.set(key, value)
+        }
+      })
+    hbaseContext = new HBaseContext(env.getSparkSession.sparkContext, hbaseConf)
+  }
+
+  override def output(df: Dataset[Row], environment: SparkEnvironment): Unit = {
+    var dfWithStringFields = df
+    val colNames = df.columns
+    val catalog = config.getString("catalog")
+    val stagingDir = config.getString("staging_dir") + "/" + System.currentTimeMillis().toString
+
+    // convert all columns type to string
+    for (colName <- colNames) {
+      dfWithStringFields = dfWithStringFields.withColumn(colName, col(colName).cast(DataTypes.StringType))
+    }
+
+    val parameters = Map(HBaseTableCatalog.tableCatalog -> catalog)
+    val htc = HBaseTableCatalog(parameters)
+    val tableName = TableName.valueOf(htc.namespace + ":" + htc.name)
+    val columnFamily = htc.getColumnFamilies
+    val save_mode = config.getString("save_mode").toLowerCase
+    val hbaseConn = ConnectionFactory.createConnection(hbaseConf)
+
+    try {
+      if (save_mode == HbaseSaveMode.Overwrite.toString.toLowerCase) {
+        truncateHTable(hbaseConn, tableName)
+      }
+
+      def familyQualifierToByte: Set[(Array[Byte], Array[Byte], String)] = {
+        if (columnFamily == null || colNames == null) throw new Exception("null can't be convert to Bytes")
+        colNames.filter(htc.getField(_).cf != HBaseTableCatalog.rowKey).map(colName => (Bytes.toBytes(htc.getField(colName).cf), Bytes.toBytes(colName), colName)).toSet
+      }
+
+      hbaseContext.bulkLoadThinRows[Row](dfWithStringFields.rdd,
+        tableName,
+        r => {
+          val rawPK = new StringBuilder
+          for (c <- htc.getRowKey) {
+            rawPK.append(r.getAs[String](c.colName))
+          }
+
+          val rkBytes = rawPK.toString.getBytes()
+          val familyQualifiersValues = new FamiliesQualifiersValues
+          val fq = familyQualifierToByte
+          for (c <- fq) {
+            breakable {
+              val family = c._1
+              val qualifier = c._2
+              val value = r.getAs[String](c._3)
+              if (value == null) {
+                break
+              }
+              familyQualifiersValues += (family, qualifier, Bytes.toBytes(value))
+            }
+          }
+          (new ByteArrayWrapper(rkBytes), familyQualifiersValues)
+        },
+        stagingDir)
+
+      val load = new LoadIncrementalHFiles(hbaseConf)
+      val table = hbaseConn.getTable(tableName)
+      load.doBulkLoad(new Path(stagingDir), hbaseConn.getAdmin, table,
+        hbaseConn.getRegionLocator(tableName))
+
+    } finally {
+      if (hbaseConn != null)
+        hbaseConn.close()
+
+      cleanUpStagingDir(stagingDir)
+    }
+  }
+
+  private def cleanUpStagingDir(stagingDir: String): Unit = {
+    val stagingPath = new Path(stagingDir)
+    val fs = stagingPath.getFileSystem(hbaseContext.config)
+    if (!fs.delete(stagingPath, true)) {
+      logWarning(s"clean staging dir ${stagingDir} failed")
+    }
+    if (fs != null)
+      fs.close()
+  }
+
+  private def truncateHTable(connection: Connection, tableName: TableName): Unit = {
+    val admin = connection.getAdmin
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName)
+      admin.truncateTable(tableName, true)
+    }
+  }
+}

--- a/plugin-spark-sink-hbase/src/main/scala/io/github/interestinglab/waterdrop/spark/sink/HbaseSaveMode.scala
+++ b/plugin-spark-sink-hbase/src/main/scala/io/github/interestinglab/waterdrop/spark/sink/HbaseSaveMode.scala
@@ -1,0 +1,8 @@
+package io.github.interestinglab.waterdrop.spark.sink
+
+object HbaseSaveMode extends Enumeration {
+
+  type HbaseSaveMode = Value
+
+  val Append, Overwrite = Value
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <module>plugin-spark-sink-console</module>
         <module>plugin-spark-sink-clickhouse</module>
         <module>plugin-spark-sink-elasticsearch</module>
+        <module>plugin-spark-sink-hbase</module>
         <module>plugin-flink-source-kafka</module>
         <module>plugin-flink-transform-sql</module>
         <module>plugin-flink-sink-console</module>
@@ -117,6 +118,12 @@
             <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql_2.11</artifactId>
+                <version>${spark.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-hive_2.11</artifactId>
                 <version>${spark.version}</version>
                 <scope>provided</scope>
             </dependency>

--- a/waterdrop-core/pom.xml
+++ b/waterdrop-core/pom.xml
@@ -113,6 +113,12 @@
         </dependency>
         <dependency>
             <groupId>io.github.interestinglab.waterdrop</groupId>
+            <artifactId>plugin-spark-sink-hbase</artifactId>
+            <version>2.0.4</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.interestinglab.waterdrop</groupId>
             <artifactId>plugin-flink-source-kafka</artifactId>
             <version>2.0.4</version>
             <!--<scope>provided</scope>-->


### PR DESCRIPTION
Depends on `hbase-connectors`, we could load(bulk load) data into hbase by spark.

For fixing version conflicts, i changed `org.apache.phoenix.phoenix-spark` dependency version of `plugin-spark-phoenix-core`  to `5.0.0-HBase-2.0 `

PTAL

@garyelephant @RickyHuo 